### PR TITLE
Add inverse_normal flag to linecast data

### DIFF
--- a/echo/data/Data.hx
+++ b/echo/data/Data.hx
@@ -196,14 +196,19 @@ class IntersectionData implements IPooled {
    * The normal vector (direction) of the Line's penetration into the Shape.
    */
   public var normal:Vector2;
+  /**
+    Indicates if normal was inversed and usually occurs when Line penetrates into the Shape from the inside.
+  **/
+  public var inverse_normal:Bool;
 
   public var pooled:Bool;
 
-  public static inline function get(distance:Float, overlap:Float, x:Float, y:Float, normal_x:Float, normal_y:Float):IntersectionData {
+  public static inline function get(distance:Float, overlap:Float, x:Float, y:Float, normal_x:Float, normal_y:Float,
+      inverse_normal:Bool = false):IntersectionData {
     var i = _pool.get();
     i.line = null;
     i.shape = null;
-    i.set(distance, overlap, x, y, normal_x, normal_y);
+    i.set(distance, overlap, x, y, normal_x, normal_y, inverse_normal);
     i.pooled = false;
     return i;
   }
@@ -213,9 +218,10 @@ class IntersectionData implements IPooled {
     normal = new Vector2(0, 0);
   }
 
-  public inline function set(distance:Float, overlap:Float, x:Float, y:Float, normal_x:Float, normal_y:Float) {
+  public inline function set(distance:Float, overlap:Float, x:Float, y:Float, normal_x:Float, normal_y:Float, inverse_normal:Bool = false) {
     this.distance = distance;
     this.overlap = overlap;
+    this.inverse_normal = inverse_normal;
     hit.set(x, y);
     normal.set(normal_x, normal_y);
   }

--- a/echo/util/SAT.hx
+++ b/echo/util/SAT.hx
@@ -62,9 +62,10 @@ class SAT {
     var hit = line1.start + ua * (line1.end - line1.start);
     var distance = line1.start.distanceTo(hit);
     var overlap = line1.length - distance;
-    var l2l = line2.length * (d < 0 ? 1 : -1);
+    var inverse = d >= 0;
+    var l2l = line2.length * (inverse ? -1 : 1);
     norm.set((line2.dy - line2.y) / l2l, -(line2.dx - line2.x) / l2l);
-    return IntersectionData.get(distance, overlap, hit.x, hit.y, norm.x, norm.y);
+    return IntersectionData.get(distance, overlap, hit.x, hit.y, norm.x, norm.y, inverse);
   }
 
   public static function line_interects_rect(l:Line, r:Rect):Null<IntersectionData> {
@@ -135,7 +136,7 @@ class SAT {
       var overlap = l.length - distance;
       norm.set(hit.x - c.x, hit.y - c.y).applyNegate().divideWith(r);
 
-      var i = IntersectionData.get(distance, overlap, hit.x, hit.y, norm.x, norm.y);
+      var i = IntersectionData.get(distance, overlap, hit.x, hit.y, norm.x, norm.y, true);
       i.line = l;
       i.shape = c;
       return i;


### PR DESCRIPTION
Allows to determine if raycast hit the inside of the shape or outside of it (with assumption that polygons are of correct winding).