### PR TITLE
expose Body.data for writing

### DIFF
--- a/echo/Body.hx
+++ b/echo/Body.hx
@@ -175,7 +175,7 @@ class Body implements IDisposable {
   /**
    * Dynamic Object to store any user data on the `Body`. Useful for Callbacks.
    */
-  public var data(default, null):Dynamic;
+  public var data(default, default):Dynamic;
   /**
    * Flag to check if the Body collided with something during the step.
    * Used for debug drawing.


### PR DESCRIPTION
It seemed weird to me to have data be write-only, I guess this makes sense if you're supposed to extend Body, but for my game I'm just instancing it. Therefore, it would be really nice to have write access to the data property, or maybe it could be in the constructor as an optional argument? Great library, by the way! :)