### PR TITLE
Fix BitMask

### DIFF
--- a/echo/util/BitMask.hx
+++ b/echo/util/BitMask.hx
@@ -1,22 +1,24 @@
 package echo.util;
 
-abstract BitMask(Int) {
-  static inline function value(index:Int) return 1 << index;
-
-  @:to public function to_int():Int return value(this);
-
-  public function new() this = 0;
-
-  public inline function remove(mask:Int):Int {
-    return this = this & ~value(mask);
+abstract BitMask(Int) to Int {
+  
+  @:from
+  public static function from_int(i:Int):BitMask {
+    return new BitMask(1 << i);
   }
 
-  public inline function add(mask:Int):Int {
-    return this = this | value(mask);
+  public function new(value:Int = 0) this = value;
+
+  public inline function remove(mask:BitMask):Int {
+    return this = this & ~mask;
   }
 
-  public inline function contains(mask:Int):Bool {
-    return this & value(mask) != 0;
+  public inline function add(mask:BitMask):Int {
+    return this = this | mask;
+  }
+
+  public inline function contains(mask:BitMask):Bool {
+    return this & mask != 0;
   }
 
   public inline function clear() {


### PR DESCRIPTION
Bitshifting was occurring at the wrong time. When inputting another bitmask as a parameter, it would shift `1` by that amount. So if you had set the 7th bit to true, it would try `1 << 256` instead of just using `256` (or 128, however you count it).

This change does not manipulate the input if it's another bitmask, but it does change it if it's a normal `Int`. The `to Int` allows the binary ops to work on the bitmask inputs.

```haxe
var bm = new BitMask();
bm.add(7); // set the 7th bit to true
bm.compare(7); // true

var bm2 = new BitMask();
bm.add(7);
bm.compare(bm2); // before: false, after: true
```