### PR TITLE
Check if b can collide with a too

### DIFF
--- a/echo/Collisions.hx
+++ b/echo/Collisions.hx
@@ -215,6 +215,6 @@ class Collisions {
   }
 
   static inline function layer_match(a:Body, b:Body) {
-    return a.layer_mask.is_empty() || a.layer_mask.contains(b.layers);
+    return a.layer_mask.is_empty() || b.layer_mask.is_empty() || (a.layer_mask.contains(b.layers) && b.layer_mask.contains(a.layers));
   }
 }


### PR DESCRIPTION
The `layers` check to see if a collision took place only checks if `a` can collide with `b`, when it should also consider if `b` can collide with `a`.