### PR TITLE
Fix Vector2 rotate math

### DIFF
--- a/echo/math/Vector2.hx
+++ b/echo/math/Vector2.hx
@@ -306,8 +306,10 @@ overload extern inline function rotate(v:Vector2, radians:Float):Vector2 {
   var cos = Math.cos(radians);
   var sin = Math.sin(radians);
 
+  var tmpX = v.x;
+
   v.x = v.x * cos - v.y * sin;
-  v.y = v.x * sin + v.y * cos;
+  v.y = tmpX * sin + v.y * cos;
 
   return v;
 }


### PR DESCRIPTION
This was rotating the vector's x, then using that value to calculate the vector's y. Now it holds a temporary X to properly calculate the Y value of the vector