### PR TITLE
check that body has quadtree data before trying to remove it

### DIFF
--- a/echo/util/QuadTree.hx
+++ b/echo/util/QuadTree.hx
@@ -119,7 +119,7 @@ class QuadTree extends AABB {
     if (leaf) {
       var i = 0;
       while (i < contents.length) {
-        if (contents[i] != null && contents[i].id == data.id) {
+        if (contents[i] != null && data != null && contents[i].id == data.id) {
           contents[i] = null;
           contents_count--;
           return true;


### PR DESCRIPTION
Simple PR to fix a little bug I found. I was trying to remove a body from the world that I hadn't added in the first place, which was causing a crash. This just checks that the body has valid quadtree data before trying to delete it.

`Null access .id
Called from echo.util.QuadTree.remove (echo/util/QuadTree.hx line 122)
Called from echo.World.remove (echo/World.hx line 105)
Called from en.Room.clearCollision (en/Room.hx line 97)
`