### PR TITLE
Shape Collision data ordering

### DIFF
--- a/echo/Shape.hx
+++ b/echo/Shape.hx
@@ -206,11 +206,11 @@ class Shape #if cog implements cog.IComponent #end {
 
   public function collides(s:Shape):Null<CollisionData> return null;
 
-  function collide_rect(r:Rect):Null<CollisionData> return null;
+  function collide_rect(r:Rect, flip:Bool = false):Null<CollisionData> return null;
 
-  function collide_circle(c:Circle):Null<CollisionData> return null;
+  function collide_circle(c:Circle, flip:Bool = false):Null<CollisionData> return null;
 
-  function collide_polygon(p:Polygon):Null<CollisionData> return null;
+  function collide_polygon(p:Polygon, flip:Bool = false):Null<CollisionData> return null;
 
   function toString() {
     var s = switch (type) {

--- a/echo/shape/Circle.hx
+++ b/echo/shape/Circle.hx
@@ -87,13 +87,16 @@ class Circle extends Shape implements Poolable {
     return false;
   }
 
-  override inline function collides(s:Shape):Null<CollisionData> return s.collide_circle(this);
+  // collision calculated as s against this. So flip result
+  override inline function collides(s:Shape):Null<CollisionData> return s.collide_circle(this, true);
 
-  override inline function collide_rect(r:Rect):Null<CollisionData> return r.rect_and_circle(this, true);
+  // collision calculated as r against this. So invert flip value
+  override inline function collide_rect(r:Rect, flip:Bool = false):Null<CollisionData> return r.rect_and_circle(this, !flip);
 
-  override inline function collide_circle(c:Circle):Null<CollisionData> return c.circle_and_circle(this);
+  // collision calculated as c against this. So invert flip value
+  override inline function collide_circle(c:Circle, flip:Bool = false):Null<CollisionData> return c.circle_and_circle(this, !flip);
 
-  override inline function collide_polygon(p:Polygon):Null<CollisionData> return this.circle_and_polygon(p, true);
+  override inline function collide_polygon(p:Polygon, flip:Bool = false):Null<CollisionData> return this.circle_and_polygon(p, flip);
 
   // getters
   inline function get_radius():Float return local_radius * scale_x;

--- a/echo/shape/Polygon.hx
+++ b/echo/shape/Polygon.hx
@@ -5,8 +5,8 @@ import echo.shape.*;
 import echo.util.AABB;
 import echo.util.Poolable;
 
-using echo.util.SAT;
 using echo.math.Vector2;
+using echo.util.SAT;
 
 class Polygon extends Shape implements Poolable {
   /**
@@ -197,13 +197,16 @@ class Polygon extends Shape implements Poolable {
     return false;
   }
 
-  override inline function collides(s:Shape):Null<CollisionData> return s.collide_polygon(this);
+  // collision calculated as s against this. So flip result
+  override inline function collides(s:Shape):Null<CollisionData> return s.collide_polygon(this, true);
 
-  override inline function collide_rect(r:Rect):Null<CollisionData> return r.rect_and_polygon(this, true);
+  // collision calculated as r against this. So invert flip value
+  override inline function collide_rect(r:Rect, flip:Bool = false):Null<CollisionData> return r.rect_and_polygon(this, !flip);
 
-  override inline function collide_circle(c:Circle):Null<CollisionData> return c.circle_and_polygon(this);
+  // collision calculated as c against this. So invert flip value
+  override inline function collide_circle(c:Circle, flip:Bool = false):Null<CollisionData> return c.circle_and_polygon(this, !flip);
 
-  override inline function collide_polygon(p:Polygon):Null<CollisionData> return p.polygon_and_polygon(this, true);
+  override inline function collide_polygon(p:Polygon, flip:Bool = false):Null<CollisionData> return this.polygon_and_polygon(p, flip);
 
   override inline function get_top():Float {
     if (count == 0 || vertices[0] == null) return y;

--- a/echo/shape/Rect.hx
+++ b/echo/shape/Rect.hx
@@ -1,10 +1,10 @@
 package echo.shape;
 
-import echo.util.AABB;
-import echo.shape.*;
-import echo.util.Poolable;
 import echo.data.Data;
 import echo.math.Vector2;
+import echo.shape.*;
+import echo.util.AABB;
+import echo.util.Poolable;
 
 using echo.util.SAT;
 
@@ -174,13 +174,14 @@ class Rect extends Shape implements Poolable {
     return false;
   }
 
-  override inline function collides(s:Shape):Null<CollisionData> return s.collide_rect(this);
+  // collision calculated as s against this. So flip result
+  override inline function collides(s:Shape):Null<CollisionData> return s.collide_rect(this, true);
 
-  override inline function collide_rect(r:Rect):Null<CollisionData> return r.rect_and_rect(this);
+  override inline function collide_rect(r:Rect, flip:Bool = false):Null<CollisionData> return this.rect_and_rect(r, flip);
 
-  override inline function collide_circle(c:Circle):Null<CollisionData> return this.rect_and_circle(c);
+  override inline function collide_circle(c:Circle, flip:Bool = false):Null<CollisionData> return this.rect_and_circle(c, flip);
 
-  override inline function collide_polygon(p:Polygon):Null<CollisionData> return this.rect_and_polygon(p);
+  override inline function collide_polygon(p:Polygon, flip:Bool = false):Null<CollisionData> return this.rect_and_polygon(p, flip);
 
   override function set_parent(?body:Body) {
     super.set_parent(body);


### PR DESCRIPTION
I have run into a bug the previous two game jams I've participated in where the `Array<CollisionData>` passed into the listener callbacks was flipped from the order that `a` and `b` are passed in. More concretely, this is happening:

```
sa matches body a: false
sb matches body b: false
```

This PR fixes ordering of shape collision data so listener data matches order of bodies by properly passing the `flip` value through the various `collide*` functions.