### PR TITLE
build actions to use heaps 1.10.0 explicitly

### DIFF
--- a/.github/composites/build/action.yml
+++ b/.github/composites/build/action.yml
@@ -16,7 +16,7 @@ runs:
         shell: bash
         run: |
           haxelib git dox https://github.com/HaxeFoundation/dox.git
-          haxelib git heaps https://github.com/HeapsIO/heaps.git
+          haxelib git heaps https://github.com/HeapsIO/heaps.git 1.10.0
           haxelib dev echo .
           
       - name: Run Builds


### PR DESCRIPTION
Using the `git` version of heaps exposes the build actions of this repo to potential instability as things change. This explicitly uses the 1.10.0 release to provide some stability in the deps required.